### PR TITLE
added array.find ponyfill

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,11 +1,12 @@
 var path = require('path'),
     fs = require('fs'),
     yaml = require('yamlparser'),
+    find = require('array-find'),
     regexes_base_path = 'node_modules/uap-core/regexes.yaml',
-    uap_regexes_path = [
+    uap_regexes_path = find([
         path.join(__dirname, regexes_base_path),
         path.join(__dirname, '../..', regexes_base_path)
-    ].find(fs.existsSync),
+    ], fs.existsSync),
     refImpl = require('uap-ref-impl')(readYAML(uap_regexes_path));
 
 function readYAML(file) {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "homepage": "https://github.com/fedot/node-uap",
   "dependencies": {
+    "array-find": "^1.0.0",
     "uap-core": "git://github.com/ua-parser/uap-core",
     "uap-ref-impl": "0.2.0",
     "yamlparser": "0.0.2"


### PR DESCRIPTION
Hey @fedot 
I have added ponyfill for ES6 array.find method, because it breaks my dependent package.
